### PR TITLE
Add zalgo filter & option

### DIFF
--- a/BotCatMaxy/Models/ModerationSettings.cs
+++ b/BotCatMaxy/Models/ModerationSettings.cs
@@ -26,6 +26,7 @@ namespace BotCatMaxy.Models
         public ushort allowedCaps = 0;
         public bool useOwnerID = false;
         public bool invitesAllowed = true;
+        public bool zalgoAllowed = true;
         public uint? maxEmojis = null;
         public bool moderateNames = false;
         public ushort? maxNewLines = null;

--- a/BotCatMaxy/Startup/AutoFilter.cs
+++ b/BotCatMaxy/Startup/AutoFilter.cs
@@ -205,7 +205,7 @@ namespace BotCatMaxy
                     //Checks if a message contains ugly, unwanted text t̨̠̱̭͓̠ͪ̈́͌ͪͮ̐͒h̲̱̯̀͂̔̆̌͊ͅà̸̻͌̍̍ͅt͕̖̦͂̎͂̂ͮ͜ ̲͈̥͒ͣ͗̚l̬͚̺͚͎̆͜ͅo͔̯̖͙ͩõ̲̗̎͆͜k̦̭̮̺ͮ͆̀ ͙̍̂͘l̡̮̱̤͍̜̲͙̓̌̐͐͂̓i͙̬ͫ̀̒͑̔͐k̯͇̀ͭe̎͋̓́ ̥͖̼̬ͪ̆ṫ͏͕̳̞̯h̛̼͔ͩ̑̿͑i͍̲̽ͮͪsͦ͋ͦ̌͗ͭ̋
                     //Props to Mathias Bynens for the regex string
                     const string zalgoRegex = @"([\0-\u02FF\u0370-\u1AAF\u1B00-\u1DBF\u1E00-\u20CF\u2100-\uD7FF\uE000-\uFE1F\uFE30-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])([\u0300-\u036F\u1AB0-\u1AFF\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]+)";
-                    if (modSettings.zalgoAllowed)
+                    if (modSettings.zalgoAllowed == false)
                     {
                         MatchCollection matches = Regex.Matches(message.Content, zalgoRegex, regexOptions);
                         if (matches.Any())
@@ -814,7 +814,7 @@ namespace BotCatMaxy
             settings.zalgoAllowed = !settings.zalgoAllowed;
             settings.SaveToFile();
 
-            await message.ModifyAsync(msg => msg.Content = "set zalgo allowed to " + settings.zalgoAllowed.ToString().ToLower());
+            await message.ModifyAsync(msg => msg.Content = "Set zalgo allowed to " + settings.zalgoAllowed.ToString().ToLower());
         }
 
         [Command("removeword")]

--- a/BotCatMaxy/Startup/AutoFilter.cs
+++ b/BotCatMaxy/Startup/AutoFilter.cs
@@ -202,6 +202,16 @@ namespace BotCatMaxy
                                 }
                     }
 
+                    //Checks if a message contains ugly, unwanted text t̨̠̱̭͓̠ͪ̈́͌ͪͮ̐͒h̲̱̯̀͂̔̆̌͊ͅà̸̻͌̍̍ͅt͕̖̦͂̎͂̂ͮ͜ ̲͈̥͒ͣ͗̚l̬͚̺͚͎̆͜ͅo͔̯̖͙ͩõ̲̗̎͆͜k̦̭̮̺ͮ͆̀ ͙̍̂͘l̡̮̱̤͍̜̲͙̓̌̐͐͂̓i͙̬ͫ̀̒͑̔͐k̯͇̀ͭe̎͋̓́ ̥͖̼̬ͪ̆ṫ͏͕̳̞̯h̛̼͔ͩ̑̿͑i͍̲̽ͮͪsͦ͋ͦ̌͗ͭ̋
+                    //Props to Mathias Bynens for the regex string
+                    const string zalgoRegex = @"([\0-\u02FF\u0370-\u1AAF\u1B00-\u1DBF\u1E00-\u20CF\u2100-\uD7FF\uE000-\uFE1F\uFE30-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])([\u0300-\u036F\u1AB0-\u1AFF\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]+)";
+                    if (modSettings.zalgoAllowed)
+                    {
+                        MatchCollection matches = Regex.Matches(message.Content, zalgoRegex, regexOptions);
+                        if (matches.Any())
+                            await context.FilterPunish("zalgo usage", modSettings);
+                    }
+
                     const string linkRegex = @"((?:https?|steam):\/\/[^\s<]+[^<.,:;" + "\"\'\\]\\s])";
                     MatchCollection linkMatches = Regex.Matches(message.Content, linkRegex, regexOptions);
                     //if (matches != null && matches.Count > 0) await new LogMessage(LogSeverity.Info, "Filter", "Link detected").Log();
@@ -793,6 +803,18 @@ namespace BotCatMaxy
             settings.SaveToFile();
 
             await message.ModifyAsync(msg => msg.Content = "set invites allowed to " + settings.invitesAllowed.ToString().ToLower());
+        }
+
+        [Command("togglezalgowarn"), Alias("togglezalgoallowed")]
+        [HasAdmin]
+        public async Task ToggleZalgoWarn()
+        {
+            IUserMessage message = await ReplyAsync("Trying to toggle");
+            ModerationSettings settings = Context.Guild.LoadFromFile<ModerationSettings>(true);
+            settings.zalgoAllowed = !settings.zalgoAllowed;
+            settings.SaveToFile();
+
+            await message.ModifyAsync(msg => msg.Content = "set zalgo allowed to " + settings.zalgoAllowed.ToString().ToLower());
         }
 
         [Command("removeword")]


### PR DESCRIPTION
- Added zalgo option that will warn the author for "zalgo usage" with a size of 0.5
- Added option to toggle zalgo filter (`!togglezalgowarn` or `!togglezalgoallowed`)
- Added option in ModerationSettings model to toggle zalgo, defaults to true