### PR TITLE
Add emoji name to reaction filter reason

### DIFF
--- a/BotCatMaxy/Components/Filter/FilterHandler.cs
+++ b/BotCatMaxy/Components/Filter/FilterHandler.cs
@@ -139,7 +139,7 @@ namespace BotCatMaxy.Startup
                 if (settings.badUEmojis.Contains(reaction.Emote.Name))
                 {
                     await message.RemoveAllReactionsForEmoteAsync(reaction.Emote);
-                    await context.FilterPunish(gUser, "bad reaction used", settings, delete: false, warnSize: 1);
+                    await context.FilterPunish(gUser, "bad reaction used (" + reaction.Emote.Name + ")", settings, delete: false, warnSize: 1);
                 }
             }
             catch (Exception e)

--- a/BotCatMaxy/Components/Filter/FilterHandler.cs
+++ b/BotCatMaxy/Components/Filter/FilterHandler.cs
@@ -139,7 +139,7 @@ namespace BotCatMaxy.Startup
                 if (settings.badUEmojis.Contains(reaction.Emote.Name))
                 {
                     await message.RemoveAllReactionsForEmoteAsync(reaction.Emote);
-                    await context.FilterPunish(gUser, "bad reaction used (" + reaction.Emote.Name + ")", settings, delete: false, warnSize: 1);
+                    await context.FilterPunish(gUser, $"bad reaction used ({reaction.Emote.Name})", settings, delete: false, warnSize: 1);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Currently the filter only logs "bad reaction used" and not the emoji that was used. In an effort to make it clearer and easier to judge the severity of the blacklisted emoji, I am proposing this addition.