### PR TITLE
FIX: Remove links from bad word filtering

### DIFF
--- a/Tests/FilterTests.cs
+++ b/Tests/FilterTests.cs
@@ -62,6 +62,7 @@ namespace Tests
         [InlineData("I'm a calzone", "calzone", "I'm a **[calzone]**")]
         [InlineData("This is a calz0ne", "calzone", null)]
         [InlineData("I'm a calz0ne", "calzone", null)]
+        [InlineData("https://imgur.com/ac4lz0ne", null, null)]
         public async Task BadWordTheory(string input, string detected, string highlighted)
         {
             var result = input.CheckForBadWords(badWords);

--- a/src/BotCatMaxy/Components/Filter/FilterHandler.cs
+++ b/src/BotCatMaxy/Components/Filter/FilterHandler.cs
@@ -165,13 +165,13 @@ namespace BotCatMaxy.Startup
                 return; //Makes sure it's not logging a message from a bot and that it's in a discord server
             }
             context ??= new SocketCommandContext((DiscordSocketClient)client, (SocketUserMessage)message);
-            IGuildUser gUser = message.Author as IGuildUser;
-            if (chnl?.Guild == null || gUser.HasAdmin()) return;
-            var guild = chnl.Guild;
+            var gUser = message.Author as IGuildUser;
+            if (gUser?.Guild == null || gUser.HasAdmin()) return;
+            IGuild guild = chnl.Guild;
 
             try
             {
-                ModerationSettings modSettings = guild.LoadFromFile<ModerationSettings>();
+                var modSettings = guild.LoadFromFile<ModerationSettings>();
                 var filterSettings = guild.LoadFromFile<FilterSettings>();
                 List<BadWord> badWords = guild.LoadFromFile<BadWordList>()?.badWords;
 

--- a/src/BotCatMaxy/Components/Filter/FilterUtilities.cs
+++ b/src/BotCatMaxy/Components/Filter/FilterUtilities.cs
@@ -18,10 +18,14 @@ namespace BotCatMaxy.Components.Filter
     public static class FilterUtilities
     {
         readonly static char[] splitters = @"#.,/\|=_- ".ToCharArray();
+        readonly static Regex linkRegularExpression = new(@"(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?", RegexOptions.IgnoreCase);
 
         public static (BadWord word, int? pos) CheckForBadWords(this string message, BadWord[] badWords)
         {
             if (badWords?.Length is null or 0) return (null, null);
+
+            //Remove links from the message
+            message = linkRegularExpression.Replace(message, "");
 
             //Checks for bad words
             var sb = new StringBuilder(message.Length);

--- a/src/BotCatMaxy/Startup/StatusManager.cs
+++ b/src/BotCatMaxy/Startup/StatusManager.cs
@@ -1,4 +1,5 @@
-﻿using Discord;
+﻿using System;
+using Discord;
 using Discord.WebSocket;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,26 +30,33 @@ namespace BotCatMaxy
 
         public async Task CheckStatus()
         {
-            string status = null;
-            switch (statusPos)
+            try
             {
-                case 0:
-                    status = $"version {version}";
-                    statusPos++;
-                    break;
-                case 1:
-                    status = "with info at https://bot.blackcatmaxy.com";
-                    statusPos++;
-                    break;
-                case 2:
-                    status = "Donate at https://donate.blackcatmaxy.com to help keep the bot running";
-                    statusPos = 0;
-                    break;
-                default:
-                    await new LogMessage(LogSeverity.Error, "Status", "Reached invalid status").Log();
-                    break;
+                string status = null;
+                switch (statusPos)
+                {
+                    case 0:
+                        status = $"version {version}";
+                        statusPos++;
+                        break;
+                    case 1:
+                        status = "with info at https://bot.blackcatmaxy.com";
+                        statusPos++;
+                        break;
+                    case 2:
+                        status = "Donate at https://donate.blackcatmaxy.com to help keep the bot running";
+                        statusPos = 0;
+                        break;
+                    default:
+                        await new LogMessage(LogSeverity.Error, "Status", "Reached invalid status").Log();
+                        break;
+                }
+                await client.SetGameAsync(status);
             }
-            await client.SetGameAsync(status);
+            catch (Exception e)
+            {
+                await new LogMessage(LogSeverity.Error, "Status", "Something went wrong setting status", e).Log();
+            }
         }
     }
 }

--- a/src/BotCatMaxy/Startup/TempActions.cs
+++ b/src/BotCatMaxy/Startup/TempActions.cs
@@ -3,12 +3,10 @@ using BotCatMaxy.Data;
 using BotCatMaxy.Models;
 using BotCatMaxy.Moderation;
 using Discord;
-using Discord.Net;
 using Discord.Rest;
 using Discord.WebSocket;
 using Humanizer;
 using Polly;
-using Polly.Retry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,8 +20,6 @@ namespace BotCatMaxy
         readonly DiscordSocketClient client;
         public static CurrentTempActionInfo currentInfo = new CurrentTempActionInfo();
         public static CachedTempActionInfo cachedInfo = new CachedTempActionInfo();
-        private static readonly int[] ignoredHTTPErrors = { 500, 503, 530 };
-        private static AsyncRetryPolicy retryPolicy;
         private Timer timer;
 
         public TempActions(DiscordSocketClient client)
@@ -31,9 +27,6 @@ namespace BotCatMaxy
             this.client = client;
             client.Ready += Ready;
             client.UserJoined += CheckNewUser;
-            retryPolicy = Policy
-                .Handle<HttpException>(e => ignoredHTTPErrors.Contains((int)e.HttpCode))
-                .RetryAsync(3);
         }
 
         private async Task Ready()
@@ -87,11 +80,10 @@ namespace BotCatMaxy
                             {
                                 try
                                 {
-                                    var banResult = await retryPolicy.ExecuteAndCaptureAsync(async () => await sockGuild.GetBanAsync(tempBan.User, requestOptions));
-                                    RestBan ban = banResult.FinalHandledResult;
+                                    RestBan ban = await sockGuild.GetBanAsync(tempBan.User, requestOptions);
                                     if (ban == null)
                                     { //If manual unban
-                                        var user = await client.Rest.GetUserAsync(tempBan.User, requestOptions);
+                                        var user = await client.Rest.GetUserAsync(tempBan.User);
                                         currentInfo.editedBans.Remove(tempBan);
                                         user?.TryNotify($"As you might know, you have been manually unbanned in {sockGuild.Name} discord");
                                         //_ = new LogMessage(LogSeverity.Warning, "TempAction", "Tempbanned person isn't banned").Log();
@@ -103,7 +95,7 @@ namespace BotCatMaxy
                                     else if (DateTime.UtcNow >= tempBan.DateBanned.Add(tempBan.Length))
                                     {
                                         RestUser rUser = ban.User;
-                                        await retryPolicy.ExecuteAsync(async () => await sockGuild.RemoveBanAsync(tempBan.User, requestOptions));
+                                        await sockGuild.RemoveBanAsync(tempBan.User, requestOptions);
                                         currentInfo.editedBans.Remove(tempBan);
                                         DiscordLogging.LogEndTempAct(sockGuild, rUser, "bann", tempBan.Reason, tempBan.Length);
                                     }
@@ -146,7 +138,7 @@ namespace BotCatMaxy
                                     { //Normal mute end
                                         if (gUser != null)
                                         {
-                                            await retryPolicy.ExecuteAsync(async () => await gUser.RemoveRoleAsync(mutedRole, requestOptions));
+                                            await gUser.RemoveRoleAsync(mutedRole, requestOptions);
                                         } // if user not in guild || if user doesn't contain muted role (successfully removed?
                                         if (gUser == null || !gUser.RoleIds.Contains(settings.mutedRole))
                                         { //Doesn't remove tempmute if unmuting fails
@@ -205,13 +197,11 @@ namespace BotCatMaxy
 
             currentInfo.checking = true;
             DateTime start = DateTime.UtcNow;
-            var timeoutPolicy = Policy.TimeoutAsync(40, Polly.Timeout.TimeoutStrategy.Optimistic, onTimeoutAsync: async (context, timespan, task) =>
-            {
-                await new LogMessage(LogSeverity.Critical, "TempAct",
-                    $"TempAct check canceled at {DateTime.UtcNow.Subtract(start).Humanize(precision: 2)} and through {currentInfo?.checkedGuilds}/{client.Guilds.Count} guilds").Log();
-                //Won't continue to below so have to do this?
-                ResetInfo(start);
-            });
+            var timeoutPolicy = Policy.TimeoutAsync(40, Polly.Timeout.TimeoutStrategy.Optimistic, onTimeoutAsync: async (context, timespan, task) => {
+                    await new LogMessage(LogSeverity.Critical, "TempAct",
+                        $"TempAct check canceled at {DateTime.UtcNow.Subtract(start).Humanize(precision: 2)} and through {currentInfo?.checkedGuilds}/{client.Guilds.Count} guilds").Log();
+                    //Won't continue to below so have to do this?
+                    ResetInfo(start); });
             await timeoutPolicy.ExecuteAsync(async ct => await CheckTempActs(client, ct: ct), CancellationToken.None, false);
             //Won't continue if above times out?
             ResetInfo(start);


### PR DESCRIPTION
This uses a simple Regex to replace URLs in messages with `""` (basically removing them).

This PR was requested by Cleric for BGD.