### PR TITLE
Add support for threads and other new Discord API features by switching to Discord.NET Labs

### DIFF
--- a/src/BotCatMaxy/BotCatMaxy.csproj
+++ b/src/BotCatMaxy/BotCatMaxy.csproj
@@ -26,12 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Addons.Hosting" Version="4.0.2" />
-    <PackageReference Include="Discord.Addons.Preconditions" Version="2.2.0-dev3" />
-    <PackageReference Include="Discord.InteractivityAddon" Version="2.4.0" />
-    <PackageReference Include="Discord.Net" Version="2.4.0" />
-    <PackageReference Include="Discord.Net.Commands" Version="2.4.0" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.4.0" />
+    <PackageReference Include="Discord.Addons.Hosting" Version="4.0.2-labs" />
+    <PackageReference Include="Discord.InteractivityAddon.Labs" Version="2.4.1-labs-20210709.1" />
+    <PackageReference Include="Discord.Net.Labs" Version="3.0.2" />
     <PackageReference Include="DotNetEnv" Version="2.1.1" />
     <PackageReference Include="Humanizer.Core" Version="2.11.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />

--- a/src/BotCatMaxy/BotCatMaxy.csproj
+++ b/src/BotCatMaxy/BotCatMaxy.csproj
@@ -27,9 +27,9 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Addons.Hosting" Version="4.0.2-labs" />
-    <PackageReference Include="Discord.InteractivityAddon.Labs" Version="2.4.1-labs-20210709.1" />
     <PackageReference Include="Discord.Net.Labs" Version="3.0.2" />
     <PackageReference Include="DotNetEnv" Version="2.1.1" />
+    <PackageReference Include="Fergun.Interactive.Labs" Version="1.1.0" />
     <PackageReference Include="Humanizer.Core" Version="2.11.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />

--- a/src/BotCatMaxy/Components/CommandHandling/CommandHandler.cs
+++ b/src/BotCatMaxy/Components/CommandHandling/CommandHandler.cs
@@ -1,13 +1,10 @@
-﻿using BotCatMaxy;
-using BotCatMaxy.Models;
+﻿using BotCatMaxy.Models;
 using BotCatMaxy.TypeReaders;
 using Discord;
-using Interactivity;
 using Discord.Commands;
 using Discord.Rest;
 using Discord.WebSocket;
 using Humanizer;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Globalization;
 using System.Reflection;
@@ -15,9 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord.Addons.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using BotCatMaxy.Components.Logging;
 
 namespace BotCatMaxy.Startup
 {

--- a/src/BotCatMaxy/Components/Filter/FilterCommands.cs
+++ b/src/BotCatMaxy/Components/Filter/FilterCommands.cs
@@ -4,11 +4,11 @@ using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using System;
-using Interactivity;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using BotCatMaxy.Components.Interactivity;
 
 namespace BotCatMaxy.Components.Filter
 {
@@ -39,10 +39,10 @@ namespace BotCatMaxy.Components.Filter
             }
             await ReplyAsync(embed: guildsEmbed.Build());
             SocketGuild guild;
-            Predicate<SocketMessage> filter = message => message.Channel == Context.Channel;
+            var filter = new InteractivePredicate(Context.Message);
             while (true)
             {
-                var result = await Interactivity.NextMessageAsync(filter, timeout: TimeSpan.FromMinutes(1));
+                var result = await Interactivity.NextMessageAsync(filter.EvaluateChannel, timeout: TimeSpan.FromMinutes(1));
                 if (result.Value?.Content is null or "cancel")
                 {
                     await ReplyAsync("You have timed out or canceled");
@@ -77,7 +77,7 @@ namespace BotCatMaxy.Components.Filter
                 else
                 {
                     await ReplyAsync("Are you sure you want to view the explicit filter? Reply with !confirm if you are sure.");
-                    var result = await Interactivity.NextMessageAsync(filter, timeout: TimeSpan.FromMinutes(1));
+                    var result = await Interactivity.NextMessageAsync(filter.EvaluateChannel);
                     if (result.Value?.Content.Equals("!confirm", StringComparison.InvariantCultureIgnoreCase) ?? false)
                     {
                         useExplicit = true;

--- a/src/BotCatMaxy/Components/Filter/FilterHandler.cs
+++ b/src/BotCatMaxy/Components/Filter/FilterHandler.cs
@@ -42,7 +42,7 @@ namespace BotCatMaxy.Startup
             return Task.CompletedTask;
         }
 
-        public Task HandleReaction(Cacheable<IUserMessage, ulong> cachedMessage, ISocketMessageChannel channel, SocketReaction reaction)
+        public Task HandleReaction(Cacheable<IUserMessage, ulong> cachedMessage, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
         {
             Task.Run(() => CheckReaction(cachedMessage, channel, reaction));
             return Task.CompletedTask;
@@ -126,8 +126,9 @@ namespace BotCatMaxy.Startup
             }
         }
 
-        public async Task CheckReaction(Cacheable<IUserMessage, ulong> cachedMessage, ISocketMessageChannel channel, SocketReaction reaction)
+        public async Task CheckReaction(Cacheable<IUserMessage, ulong> cachedMessage, Cacheable<IMessageChannel, ulong> cachedChannel, SocketReaction reaction)
         {
+            IMessageChannel channel = await cachedChannel.GetOrDownloadAsync();
             if ((reaction.User.IsSpecified && reaction.User.Value.IsBot) || !(channel is IGuildChannel))
             {
                 return; //Makes sure it's not logging a message from a bot and that it's in a discord server

--- a/src/BotCatMaxy/Components/Interactivity/InteractiveFunctions.cs
+++ b/src/BotCatMaxy/Components/Interactivity/InteractiveFunctions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Discord;
+using Fergun.Interactive;
+
+namespace BotCatMaxy.Components.Interactivity
+{
+    public static class InteractiveFunctions
+    {
+        private static readonly Emoji _confirmEmoji = new("\U00002705");
+        private static readonly Emoji _cancelEmoji = new("\U0000274c");
+
+        /// <summary>
+        /// Adds confirm and deny reactions to a message and then waits for the author to react.
+        /// </summary>
+        /// <param name="message">The message to check for reactions from</param>
+        /// <param name="timeout">The time to wait before the methods returns a timeout result. Defaults to 2 minutes.</param>
+        /// <returns>Returns true if didn't time out and confirm is selected</returns>
+        public static async Task<bool> TryConfirmation(this InteractiveService service, IMessage message, TimeSpan? timeout = null)
+        {
+            await message.AddReactionAsync(_cancelEmoji);
+            await message.AddReactionAsync(_confirmEmoji);
+            var reaction = await service.NextReactionAsync(reaction
+                => reaction.MessageId == message.Id && reaction.UserId == message.Author.Id, timeout: timeout ?? TimeSpan.FromMinutes(2));
+
+            return (reaction.IsSuccess && Equals(reaction.Value.Emote, _confirmEmoji));
+        }
+    }
+}

--- a/src/BotCatMaxy/Components/Interactivity/InteractiveModule.cs
+++ b/src/BotCatMaxy/Components/Interactivity/InteractiveModule.cs
@@ -1,7 +1,8 @@
-﻿using Interactivity;
-using System;
+﻿using System;
+using Discord.Commands;
+using Fergun.Interactive;
 
-namespace Discord.Commands
+namespace BotCatMaxy.Components.Interactivity
 {
     /// <summary>
     /// Wrapper around <seealso cref="ModuleBase{T}"/> with T as <see cref="ICommandContext"/>
@@ -15,9 +16,9 @@ namespace Discord.Commands
         /// </summary>
         public InteractiveModule(IServiceProvider service) : base()
         {
-            Interactivity = (InteractivityService)service.GetService(typeof(InteractivityService));
+            Interactivity = (InteractiveService)service.GetService(typeof(InteractiveService));
         }
 
-        protected InteractivityService Interactivity { get; init; }
+        protected InteractiveService Interactivity { get; }
     }
 }

--- a/src/BotCatMaxy/Components/Interactivity/InteractivePredicate.cs
+++ b/src/BotCatMaxy/Components/Interactivity/InteractivePredicate.cs
@@ -1,0 +1,32 @@
+using System;
+using Discord;
+using Discord.WebSocket;
+
+namespace BotCatMaxy.Components.Interactivity
+{
+    /// <summary>
+    /// A class containing functions around matching messages,
+    /// mostly to be (re)usable as filters in Interactivity functions.
+    /// </summary>
+    public class InteractivePredicate
+    {
+        public InteractivePredicate(IMessage message, bool requireAuthor = true)
+        {
+            _message = message;
+            _requireAuthor = requireAuthor;
+        }
+
+        private readonly IMessage _message;
+        private readonly bool _requireAuthor;
+
+        /// <summary>
+        /// Evaluate a message's channel.
+        /// </summary>
+        /// <returns>If message originated from same channel as stored message.</returns>
+        public bool EvaluateChannel(SocketMessage message)
+        {
+            //Won't evaluate right hand side if matchAuthor is !false since || is lazy
+            return message.Channel.Id == _message.Channel.Id && (!_requireAuthor || message.Author.Id == _message.Author.Id);
+        }
+    }
+}

--- a/src/BotCatMaxy/Components/Interactivity/MessagePredicate.cs
+++ b/src/BotCatMaxy/Components/Interactivity/MessagePredicate.cs
@@ -1,0 +1,14 @@
+using Discord;
+
+namespace BotCatMaxy.Components.Interactivity
+{
+    public class MessagePredicate
+    {
+        public IMessage Message { get; init; }
+
+        public bool Evaluate(IMessage other)
+        {
+            return Message.Id == other.Id;
+        }
+    }
+}

--- a/src/BotCatMaxy/Components/Logging/LoggingCommands.cs
+++ b/src/BotCatMaxy/Components/Logging/LoggingCommands.cs
@@ -5,6 +5,7 @@ using Discord.Commands;
 using Discord.WebSocket;
 using System;
 using System.Threading.Tasks;
+using BotCatMaxy.Components.Interactivity;
 
 namespace BotCatMaxy.Components.Logging
 {

--- a/src/BotCatMaxy/Components/Logging/LoggingHandler.cs
+++ b/src/BotCatMaxy/Components/Logging/LoggingHandler.cs
@@ -35,7 +35,7 @@ namespace BotCatMaxy.Startup
             return Task.CompletedTask;
         }
 
-        private Task HandleDelete(Cacheable<IMessage, ulong> message, ISocketMessageChannel channel)
+        private Task HandleDelete(Cacheable<IMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel)
         {
             Task.Run(() => LogDelete(message, channel));
             return Task.CompletedTask;
@@ -108,8 +108,9 @@ namespace BotCatMaxy.Startup
             }
         }
 
-        private async Task LogDelete(Cacheable<IMessage, ulong> message, ISocketMessageChannel channel)
+        private async Task LogDelete(Cacheable<IMessage, ulong> message, Cacheable<IMessageChannel, ulong> cachedChannel)
         {
+            IMessageChannel channel = await cachedChannel.GetOrDownloadAsync();
             try
             {
                 if (!(channel is SocketGuildChannel)) return;

--- a/src/BotCatMaxy/Program.cs
+++ b/src/BotCatMaxy/Program.cs
@@ -39,7 +39,7 @@ namespace BotCatMaxy
                     var path = "Properties/BotCatMaxy";
 #if DEBUG
                     if (File.Exists($"{path}.DEBUG.ini"))
-                        path += ".DEBUG";                    
+                        path += ".DEBUG";
 #endif
                     Console.WriteLine($"Loading config from {path}.ini");
                     config.AddIniFile($"{path}.ini", optional: true, reloadOnChange: true);
@@ -86,6 +86,7 @@ namespace BotCatMaxy
                     }));
 
                     services.AddHostedService<BotInfo>();
+                    services.AddHostedService<FilterHandler>();
                     services.AddHostedService<CommandHandler>();
                     services.AddHostedService<TempActionService>();
                 });

--- a/src/BotCatMaxy/Program.cs
+++ b/src/BotCatMaxy/Program.cs
@@ -54,7 +54,6 @@ namespace BotCatMaxy
                             true, //going to keep here for new guilds added, but seems to be broken for startup per https://github.com/discord-net/Discord.Net/issues/1646
                         ConnectionTimeout = 6000,
                         MessageCacheSize = 120,
-                        ExclusiveBulkDelete = false,
                         LogLevel = LogSeverity.Info,
                         DefaultRetryMode = RetryMode.AlwaysRetry,
                         GatewayIntents = GatewayIntents.GuildBans | GatewayIntents.GuildMembers |

--- a/src/BotCatMaxy/Program.cs
+++ b/src/BotCatMaxy/Program.cs
@@ -9,15 +9,13 @@ using Discord;
 using Discord.Addons.Hosting;
 using Discord.Commands;
 using Discord.WebSocket;
-using Interactivity;
+using Fergun.Interactive;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Serilog;
-using Serilog.Core;
 using Serilog.Sinks.SystemConsole.Themes;
 
 namespace BotCatMaxy
@@ -28,11 +26,11 @@ namespace BotCatMaxy
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
-                .WriteTo.Async(a => 
+                .WriteTo.Async(a =>
                     a.File("logs/log.txt", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14))
                 .WriteTo.Console(theme: AnsiConsoleTheme.Code)
                 .CreateLogger();
-            
+
             var hostBuilder = Host.CreateDefaultBuilder()
                 .UseSerilog()
                 .ConfigureAppConfiguration((context, config) =>
@@ -78,21 +76,20 @@ namespace BotCatMaxy
                     var mongo = new MongoClient(context.Configuration["DataToken"]);
                     DataManipulator.dbClient = mongo;
                     services.AddSingleton(mongo);
-                    
-                    services.AddSingleton(x =>
-                        new InteractivityService(x.GetRequiredService<DiscordSocketClient>()));
+
+                    services.AddSingleton<InteractiveService>();
                     services.AddSingleton(new CommandService(new CommandServiceConfig
                     {
                         DefaultRunMode = RunMode.Async,
                         CaseSensitiveCommands = false,
                         IgnoreExtraArgs = true
                     }));
-                    
+
                     services.AddHostedService<BotInfo>();
                     services.AddHostedService<CommandHandler>();
                     services.AddHostedService<TempActionService>();
                 });
-            
+
             try
             {
                 //Throws OptionsValidationException when Discord token isn't valid

--- a/src/Tests/Mocks/Guild/MockGuild.cs
+++ b/src/Tests/Mocks/Guild/MockGuild.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,11 +23,14 @@ namespace Tests.Mocks.Guild
         protected List<MockTextChannel> channels = new(4);
         protected List<MockBan> bans = new(4);
 
+        public Task<IReadOnlyCollection<IApplicationCommand>> BulkOverwriteApplicationCommandsAsync(ApplicationCommandProperties[] properties, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public string Name => "TestName";
 
         public int AFKTimeout => throw new NotImplementedException();
-
-        public bool IsEmbeddable => throw new NotImplementedException();
 
         public bool IsWidgetEnabled => throw new NotImplementedException();
 
@@ -54,10 +58,6 @@ namespace Tests.Mocks.Guild
 
         public ulong? AFKChannelId => throw new NotImplementedException();
 
-        public ulong DefaultChannelId => throw new NotImplementedException();
-
-        public ulong? EmbedChannelId => throw new NotImplementedException();
-
         public ulong? WidgetChannelId => throw new NotImplementedException();
 
         public ulong? SystemChannelId => throw new NotImplementedException();
@@ -77,6 +77,7 @@ namespace Tests.Mocks.Guild
         public IRole EveryoneRole => throw new NotImplementedException();
 
         public IReadOnlyCollection<GuildEmote> Emotes => throw new NotImplementedException();
+        public IReadOnlyCollection<ICustomSticker> Stickers { get; }
 
         public IReadOnlyCollection<string> Features => throw new NotImplementedException();
 
@@ -107,6 +108,7 @@ namespace Tests.Mocks.Guild
         public int? ApproximatePresenceCount => throw new NotImplementedException();
 
         public string PreferredLocale => throw new NotImplementedException();
+        public NsfwLevel NsfwLevel { get; }
 
         public CultureInfo PreferredCulture => throw new NotImplementedException();
 
@@ -159,6 +161,11 @@ namespace Tests.Mocks.Guild
             throw new NotImplementedException();
         }
 
+        public Task<IReadOnlyCollection<IThreadChannel>> GetThreadChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<ITextChannel> CreateTextChannelAsync(string name, Action<TextChannelProperties> func = null, RequestOptions options = null)
         {
             var channel = new MockTextChannel(new MockSelfUser(), this, name);
@@ -181,6 +188,52 @@ namespace Tests.Mocks.Guild
             throw new NotImplementedException();
         }
 
+        public Task<ICustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Image image, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ICustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, string path, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ICustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Stream stream, string filename,
+            RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ICustomSticker> GetStickerAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyCollection<ICustomSticker>> GetStickersAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task DeleteStickerAsync(ICustomSticker sticker, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyCollection<IApplicationCommand>> GetApplicationCommandsAsync(RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IApplicationCommand> GetApplicationCommandAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IApplicationCommand> CreateApplicationCommandAsync(ApplicationCommandProperties properties, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task DownloadUsersAsync()
         {
             userList = new(4);
@@ -191,6 +244,11 @@ namespace Tests.Mocks.Guild
             userList.Add(new MockGuildUser("Tester", this));
             userList.Add(new MockGuildUser("Testee", this));
             return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyCollection<IStageChannel>> GetStageChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
         }
 
         public Task<IVoiceChannel> GetAFKChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -272,6 +330,11 @@ namespace Tests.Mocks.Guild
             throw new NotImplementedException();
         }
 
+        public Task<IThreadChannel> GetThreadChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public IRole GetRole(ulong id)
         {
             throw new NotImplementedException();
@@ -314,6 +377,11 @@ namespace Tests.Mocks.Guild
             throw new NotImplementedException();
         }
 
+        public Task<IStageChannel> GetStageChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<IReadOnlyCollection<IVoiceChannel>> GetVoiceChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
         {
             throw new NotImplementedException();
@@ -345,11 +413,6 @@ namespace Tests.Mocks.Guild
         }
 
         public Task ModifyAsync(Action<GuildProperties> func, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/Mocks/Guild/MockGuildUser.cs
+++ b/src/Tests/Mocks/Guild/MockGuildUser.cs
@@ -69,6 +69,7 @@ namespace Tests.Mocks.Guild
         public string VoiceSessionId => throw new NotImplementedException();
 
         public bool IsStreaming => throw new NotImplementedException();
+        public DateTimeOffset? RequestToSpeakTimestamp { get; }
 
         public Task AddRoleAsync(ulong roleId, RequestOptions options = null)
         {

--- a/src/Tests/Mocks/Guild/MockTextChannel.cs
+++ b/src/Tests/Mocks/Guild/MockTextChannel.cs
@@ -17,6 +17,12 @@ namespace Tests.Mocks.Guild
 
         IReadOnlyCollection<IGuildUser> users;
 
+        public Task<IThreadChannel> CreateThreadAsync(string name, ThreadType type = ThreadType.PublicThread, ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay,
+            IMessage message = null, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsNsfw => throw new NotImplementedException();
 
         public string Topic => throw new NotImplementedException();
@@ -46,6 +52,18 @@ namespace Tests.Mocks.Guild
         }
 
         public Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IInviteMetadata> CreateInviteToApplicationAsync(ulong applicationId, int? maxAge, int? maxUses = null, bool isTemporary = false,
+            bool isUnique = false, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IInviteMetadata> CreateInviteToStreamAsync(IUser user, int? maxAge, int? maxUses = null, bool isTemporary = false,
+            bool isUnique = false, RequestOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/Mocks/MockDiscordClient.cs
+++ b/src/Tests/Mocks/MockDiscordClient.cs
@@ -57,6 +57,26 @@ namespace Tests.Mocks
             throw new NotImplementedException();
         }
 
+        public Task<IApplicationCommand> GetGlobalApplicationCommandAsync(ulong id, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyCollection<IApplicationCommand>> GetGlobalApplicationCommandsAsync(RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IApplicationCommand> CreateGlobalApplicationCommand(ApplicationCommandProperties properties, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyCollection<IApplicationCommand>> BulkOverwriteGlobalApplicationCommand(ApplicationCommandProperties[] properties, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<IReadOnlyCollection<IDMChannel>> GetDMChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
         {
             throw new NotImplementedException();

--- a/src/Tests/Mocks/MockMessage.cs
+++ b/src/Tests/Mocks/MockMessage.cs
@@ -59,6 +59,9 @@ namespace Tests.Mocks
         public MessageReference Reference => throw new NotImplementedException();
 
         public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => throw new NotImplementedException();
+        public IReadOnlyCollection<IMessageComponent> Components { get; }
+        IReadOnlyCollection<IStickerItem> IMessage.Stickers => Stickers;
+
         public IReadOnlyCollection<ISticker> Stickers { get; }
 
         public MessageFlags? Flags => throw new NotImplementedException();

--- a/src/Tests/Mocks/MockMessageChannel.cs
+++ b/src/Tests/Mocks/MockMessageChannel.cs
@@ -52,6 +52,29 @@ namespace Tests.Mocks
             throw new NotImplementedException();
         }
 
+        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null,
+            AllowedMentions allowedMentions = null, MessageReference messageReference = null,
+            MessageComponent component = null)
+        {
+            var message = new MockUserMessage(text, this, Bot);
+            messages.Insert(0, message);
+            return Task.FromResult(message as IUserMessage);
+        }
+
+        public Task<IUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null,
+            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
+            MessageReference messageReference = null, MessageComponent component = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null,
+            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
+            MessageReference messageReference = null, MessageComponent component = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
         {
             return Task.FromResult(messages.FirstOrDefault(message => message.Id == id) as IMessage);
@@ -94,23 +117,6 @@ namespace Tests.Mocks
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetUsersAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
         {
             throw new NotImplementedException();
-        }
-
-        public Task<IUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null, MessageReference messageReference = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<IUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null, MessageReference messageReference = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null)
-        {
-            var message = new MockUserMessage(text, this, Bot);
-            messages.Insert(0, message);
-            return Task.FromResult(message as IUserMessage);
         }
 
         public IUserMessage SendMessageAsOther(string text, IUser user = null)

--- a/src/Tests/Mocks/MockUser.cs
+++ b/src/Tests/Mocks/MockUser.cs
@@ -19,7 +19,14 @@ namespace Tests.Mocks
         }
 
         MockDMChannel channel;
+        public Task<IDMChannel> CreateDMChannelAsync(RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public string AvatarId => throw new NotImplementedException();
+        public string BannerId { get; }
+        public Color? AccentColor { get; }
 
         public string Discriminator => $"#{DiscriminatorValue}";
 
@@ -39,8 +46,6 @@ namespace Tests.Mocks
 
         public string Mention => $"@{Username}";
 
-        public IActivity Activity => throw new NotImplementedException();
-
         public UserStatus Status => throw new NotImplementedException();
 
         public IImmutableSet<ClientType> ActiveClients => throw new NotImplementedException();
@@ -48,6 +53,11 @@ namespace Tests.Mocks
         public IImmutableList<IActivity> Activities => throw new NotImplementedException();
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetBannerUrl(ImageFormat format = ImageFormat.Auto, ushort size = 256)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/Mocks/MockUserMessage.cs
+++ b/src/Tests/Mocks/MockUserMessage.cs
@@ -23,11 +23,6 @@ namespace Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task ModifySuppressionAsync(bool suppressEmbeds, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
-
         public Task PinAsync(RequestOptions options = null)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
As Discord's threads launch universally on September 9th BotCatMaxy is currently unable to view messages in threads as Discord.NET is stuck on an older API version pending a full rewrite at an indeterminable time. The best alternative to simply waiting is to switch to using the fork Discord.NET Labs and switch the dependencies to binary compatible versions. This way we not only have access to thread events but also other new Discord interactive features such as message components. 