### PR TITLE
Creates the guild owner command attribute

### DIFF
--- a/src/BotCatMaxy/Components/CommandHandling/Attributes/GuildOwnerAttribute.cs
+++ b/src/BotCatMaxy/Components/CommandHandling/Attributes/GuildOwnerAttribute.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using BotCatMaxy;
+
+namespace Discord.Commands
+{
+    /// <summary>
+    /// Requires the command to be executed by the owner of the current guild
+    /// </summary>
+    public class GuildOwnerAttribute : PreconditionAttribute
+    {
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command,
+            IServiceProvider services)
+        {
+            //Make sure it's in a server
+            if (context.User is IGuildUser gUser)
+            {
+                var guild = gUser.Guild;
+
+                // If this command was executed by a user with an id that matches the guild owner's, return a success
+                if (gUser.Id == guild.OwnerId)
+                    return Task.FromResult(PreconditionResult.FromSuccess());
+                else
+                    return Task.FromResult(PreconditionResult.FromError("You don't have the permissions to use this."));
+            }
+            else
+                return Task.FromResult(PreconditionResult.FromError("You must be in a guild to run this command."));
+        }
+    }
+}

--- a/src/BotCatMaxy/Misc Commands.cs
+++ b/src/BotCatMaxy/Misc Commands.cs
@@ -1,4 +1,4 @@
-﻿using BotCatMaxy.Cache;
+using BotCatMaxy.Cache;
 using BotCatMaxy.Data;
 using BotCatMaxy.Models;
 using Discord;
@@ -58,6 +58,8 @@ namespace BotCatMaxy
                 context = $"{GUILDMESSSAGE} \n**Requires administrator permission**";
             else if (command.Preconditions.Any(attribute => attribute is CanWarnAttribute))
                 context = $"{GUILDMESSSAGE} \n**Requires ability to warn**";
+            else if (command.Preconditions.Any(attribute => attribute is GuildOwnerAttribute))
+                context = $"{GUILDMESSSAGE} \n**Guild owner only**";
             else
             {
                 var permissionAttribute = command.Preconditions


### PR DESCRIPTION
Created for ease of access. Instead of having to do other wacky stuff in the command itself this attribute can be applied.