### PR TITLE
Infraction Size Enhancements & Fixes

### DIFF
--- a/src/BotCatMaxy/Components/Moderation/PunishFunctions.cs
+++ b/src/BotCatMaxy/Components/Moderation/PunishFunctions.cs
@@ -65,7 +65,7 @@ namespace BotCatMaxy.Moderation
 
         public static async Task<WarnResult> Warn(this ulong userID, float size, string reason, ITextChannel channel, IUser warnee = null, string logLink = null)
         {
-            if (size > 999 || size < 0.01)
+            if (size > 999F || size < 0.01F)
             {
                 return new WarnResult("The infraction size must be between `0.01` and `999`.");
             }

--- a/src/BotCatMaxy/Components/Moderation/PunishFunctions.cs
+++ b/src/BotCatMaxy/Components/Moderation/PunishFunctions.cs
@@ -69,6 +69,11 @@ namespace BotCatMaxy.Moderation
             {
                 return new WarnResult("The infraction size must be between `0.01` and `999`.");
             }
+            
+            if ((size * 100F) % 1F != 0F)
+            {
+                return new WarnResult("The infraction size must have two or less decimal places, like `1.01` or `1`.");
+            }
 
             try
             {


### PR DESCRIPTION
## Fixes
- [x] Fixes an issue where `0.01F` is considered smaller than `0.01` (as a double), so we just compare to a float instead of a double.

## Enhancements
- [x] Limits the size to 2 decimal places.