### PR TITLE
Filter @everyone & @here explicitly

### DIFF
--- a/src/BotCatMaxy/Components/Filter/FilterUtilities.cs
+++ b/src/BotCatMaxy/Components/Filter/FilterUtilities.cs
@@ -69,6 +69,10 @@ namespace BotCatMaxy.Components.Filter
                 {
                     //Need to override index system here since we strip characters
                     int index = strippedMessage.IndexOf(badWord.Word, StringComparison.InvariantCultureIgnoreCase);
+                    
+                    if (badWord.Word == "@everyone" || badWord.Word == "@here")
+                        index = message.IndexOf(badWord.Word, StringComparison.InvariantCultureIgnoreCase);
+                    
                     if (index > -1)
                     {
                         try


### PR DESCRIPTION
# Description
If a word is "@everyone" or "@here", and it's toggled to be detected inside another word, we'll skip the stripping of symbols so that way it only detects the pure mention.

# Enhancements
- Skip message stripping if bad word is "@everyone" or "@here" and toggled to be detected inside other words