### PR TITLE
Allow filter info to be sent in server by admins

### DIFF
--- a/src/BotCatMaxy/Components/CommandHandling/Attributes/AdminOrDMAttribute.cs
+++ b/src/BotCatMaxy/Components/CommandHandling/Attributes/AdminOrDMAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using BotCatMaxy;
+
+namespace Discord.Commands
+{
+    public class AdminOrDMAttribute : PreconditionAttribute
+    {
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command,
+            IServiceProvider services)
+        {
+            // Check if the command was run in a server
+            if (context.User is IGuildUser gUser)
+            {
+                // If this command was executed by a user with administrator permission, return a success
+                if (gUser.HasAdmin())
+                    return Task.FromResult(PreconditionResult.FromSuccess());
+                else
+                    return Task.FromResult(PreconditionResult.FromError("This command now only works in the bot's DMs"));
+            }
+            else
+                return Task.FromResult(PreconditionResult.FromSuccess());
+        }
+    }
+}

--- a/src/BotCatMaxy/Components/Filter/FilterCommands.cs
+++ b/src/BotCatMaxy/Components/Filter/FilterCommands.cs
@@ -1,4 +1,4 @@
-﻿using BotCatMaxy.Data;
+using BotCatMaxy.Data;
 using BotCatMaxy.Models;
 using Discord;
 using Discord.Commands;
@@ -27,7 +27,7 @@ namespace BotCatMaxy.Components.Filter
         [Command("list")]
         [Summary("View filter information.")]
         [Alias("info")]
-        [RequireContext(ContextType.DM, ErrorMessage = "This command now only works in the bot's DMs")]
+        [AdminOrDM]
         public async Task<RuntimeResult> ListAutoMod(string? extension = null)
         {
             var guild = await QueryMutualGuild();


### PR DESCRIPTION
Copy-pasting my reasoning from bot-dev into here

"i got tired of having to go to bcm dms and do the filter info process to find warn weights, so i made an attribute (felt more proper) that allows users with admin to bypass dm requirement but still keep dm requirement""

Tested this with help from Beagle, should be working fine