### PR TITLE
Allow servers to set appeal links, which would be sent with every ban message

### DIFF
--- a/src/BotCatMaxy/Components/Moderation/ModerationCommands.cs
+++ b/src/BotCatMaxy/Components/Moderation/ModerationCommands.cs
@@ -177,13 +177,9 @@ namespace BotCatMaxy
                 return CommandResult.FromError("User has already been banned permanently.");
             }
 
-            string newReason = $"You have been perm banned in the {Context.Guild.Name} discord for {reason}";
-
-            if (!settings.appealLink.IsNullOrEmpty())
-                newReason += $"\nUse this link to appeal: {settings.appealLink}";
-
             if (userRef.User != null)
-                await userRef.User.TryNotify(newReason);
+                await userRef.User.Notify($"permanently banned", reason, Context.Guild, Context.Message.Author, appealLink: settings.appealLink);
+                // await userRef.User.TryNotify($"You have been perm banned in the {Context.Guild.Name} discord for {reason}");
             await Context.Guild.AddBanAsync(userRef.ID, reason: reason);
             await DiscordLogging.LogTempAct(Context.Guild, Context.Message.Author, userRef, "Bann", reason, Context.Message.GetJumpUrl(), TimeSpan.Zero);
             return CommandResult.FromSuccess($"{userRef.Name(true)} has been banned for `{reason}`.");

--- a/src/BotCatMaxy/Components/Moderation/ModerationCommands.cs
+++ b/src/BotCatMaxy/Components/Moderation/ModerationCommands.cs
@@ -179,7 +179,6 @@ namespace BotCatMaxy
 
             if (userRef.User != null)
                 await userRef.User.Notify($"permanently banned", reason, Context.Guild, Context.Message.Author, appealLink: settings.appealLink);
-                // await userRef.User.TryNotify($"You have been perm banned in the {Context.Guild.Name} discord for {reason}");
             await Context.Guild.AddBanAsync(userRef.ID, reason: reason);
             await DiscordLogging.LogTempAct(Context.Guild, Context.Message.Author, userRef, "Bann", reason, Context.Message.GetJumpUrl(), TimeSpan.Zero);
             return CommandResult.FromSuccess($"{userRef.Name(true)} has been banned for `{reason}`.");

--- a/src/BotCatMaxy/Components/Moderation/Settings.cs
+++ b/src/BotCatMaxy/Components/Moderation/Settings.cs
@@ -50,7 +50,7 @@ namespace BotCatMaxy
         [Summary("Sets the link sent to all banned users to appeal. Use this command by itself to disable.")]
         [RequireContext(ContextType.Guild)]
         [HasAdmin]
-        public async Task SetAppealLink(string link = "")
+        public async Task SetAppealLink(string link = null)
         {
             ModerationSettings settings = Context.Guild.LoadFromFile<ModerationSettings>(true);
 

--- a/src/BotCatMaxy/Components/Moderation/Settings.cs
+++ b/src/BotCatMaxy/Components/Moderation/Settings.cs
@@ -1,9 +1,10 @@
-﻿using BotCatMaxy.Data;
+using BotCatMaxy.Data;
 using BotCatMaxy.Models;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using System;
+using System.Data;
 using System.Threading.Tasks;
 
 namespace BotCatMaxy
@@ -43,6 +44,27 @@ namespace BotCatMaxy
         {
             return CommandResult.FromSuccess(
                 "This is a legacy feature, if you want this done now contact blackcatmaxy@gmail.com with your guild invite and your username so I can get back to you");
+        }
+
+        [Command("setappeallink"), Alias("appeallink")]
+        [Summary("Sets the link sent to all banned users to appeal. Use this command by itself to disable.")]
+        [RequireContext(ContextType.Guild)]
+        [HasAdmin]
+        public async Task SetAppealLink(string link = "")
+        {
+            ModerationSettings settings = Context.Guild.LoadFromFile<ModerationSettings>(true);
+
+            if (link.IsNullOrEmpty())
+                settings.appealLink = null;
+            else
+                settings.appealLink = link;
+
+            settings.SaveToFile();
+
+            if (link.IsNullOrEmpty())
+                await ReplyAsync("Cleared appeal link");
+            else
+                await ReplyAsync($"Set the appeal link to `{link}`");
         }
 
         [Command("allowwarn"), Alias("allowtowarn")]

--- a/src/BotCatMaxy/Components/Moderation/Settings.cs
+++ b/src/BotCatMaxy/Components/Moderation/Settings.cs
@@ -61,7 +61,7 @@ namespace BotCatMaxy
 
             settings.SaveToFile();
 
-            if (link.IsNullOrEmpty() || link == "none" || link == "null")
+            if (link.IsNullOrEmpty() || link.ToLower() == "none" || link.ToLower() == "null")
                 await ReplyAsync("Cleared appeal link");
             else
                 await ReplyAsync($"Set the appeal link to `{link}`");

--- a/src/BotCatMaxy/Components/Moderation/Settings.cs
+++ b/src/BotCatMaxy/Components/Moderation/Settings.cs
@@ -61,7 +61,7 @@ namespace BotCatMaxy
 
             settings.SaveToFile();
 
-            if (link.IsNullOrEmpty())
+            if (link.IsNullOrEmpty() || link == "none" || link == "null")
                 await ReplyAsync("Cleared appeal link");
             else
                 await ReplyAsync($"Set the appeal link to `{link}`");

--- a/src/BotCatMaxy/Components/Moderation/TempBanCommands.cs
+++ b/src/BotCatMaxy/Components/Moderation/TempBanCommands.cs
@@ -49,9 +49,10 @@ public class TempBanCommands : InteractiveModule
         if (time.TotalMinutes < 1)
             return CommandResult.FromError("Can't temp-ban for less than a minute.");
 
+        ModerationSettings settings = Context.Guild.LoadFromFile<ModerationSettings>(false);
+
         if (!(Context.Message.Author as IGuildUser).HasAdmin())
         {
-            ModerationSettings settings = Context.Guild.LoadFromFile<ModerationSettings>(false);
             if (settings?.maxTempAction != null && time > settings.maxTempAction)
             {
                 return CommandResult.FromError("You are not allowed to punish for that long.");
@@ -71,7 +72,7 @@ public class TempBanCommands : InteractiveModule
         {
             try
             {
-                await userRef.User.Notify($"tempbanned for {time.LimitedHumanize()}", reason, Context.Guild, Context.Message.Author);
+                await userRef.User.Notify($"tempbanned for {time.LimitedHumanize()}", reason, Context.Guild, Context.Message.Author, appealLink: settings.appealLink);
             }
             catch (Exception e)
             {

--- a/src/BotCatMaxy/Models/ModerationSettings.cs
+++ b/src/BotCatMaxy/Models/ModerationSettings.cs
@@ -1,4 +1,4 @@
-﻿using BotCatMaxy.Data;
+using BotCatMaxy.Data;
 using System;
 using System.Collections.Generic;
 
@@ -12,6 +12,9 @@ namespace BotCatMaxy.Models
         public List<ulong> ableToWarn = new();
         public List<ulong> ableToBan = new();
         public Dictionary<string, double> dynamicSlowmode = new();
+        #nullable enable
+        public string? appealLink = null;
+        #nullable disable
         public TimeSpan? maxTempAction = null;
         public ulong mutedRole = 0;
         public bool useOwnerID = false;

--- a/src/BotCatMaxy/Utilities/NotifyUtilities.cs
+++ b/src/BotCatMaxy/Utilities/NotifyUtilities.cs
@@ -25,7 +25,7 @@ namespace BotCatMaxy
                 .WithColor(color);
 
             if (!appealLink.IsNullOrEmpty())
-                embed.AddField("Appeal", $"Click **[here]({appealLink})** if you'd like to appeal.");
+                embed.AddField("Appeal", $"**[Click here]({appealLink})** if you'd like to appeal.");
 
             if (author != null) embed.WithFooter($"Done by {author.Username}#{author.Discriminator}", author.GetAvatarUrl());
             await user.TryNotify(embed.Build());

--- a/src/BotCatMaxy/Utilities/NotifyUtilities.cs
+++ b/src/BotCatMaxy/Utilities/NotifyUtilities.cs
@@ -1,4 +1,4 @@
-﻿using Discord;
+using Discord;
 using Discord.WebSocket;
 using System;
 using System.Collections.Generic;
@@ -13,14 +13,21 @@ namespace BotCatMaxy
         /// <summary>
         /// Embeds a DM to a user about an action with a reason
         /// </summary>
-        public static async Task Notify(this IUser user, string action, string reason, IGuild guild, IUser author = null, Color color = default)
+        public static async Task Notify(this IUser user, string action, string reason, IGuild guild, IUser author = null, Color color = default, string appealLink = "")
         {
+            var newReason = reason;
+
             if (color == default) color = Color.LightGrey;
             var embed = new EmbedBuilder()
-                .AddField($"You have been {action}", reason)
                 .WithCurrentTimestamp()
                 .WithGuildAsAuthor(guild)
                 .WithColor(color);
+
+            if (!appealLink.IsNullOrEmpty())
+                newReason += $"\n\n[Click here to appeal.]({appealLink})";
+
+            embed.AddField($"You have been {action}", newReason);
+
             if (author != null) embed.WithFooter($"Done by {author.Username}#{author.Discriminator}", author.GetAvatarUrl());
             await user.TryNotify(embed.Build());
         }

--- a/src/BotCatMaxy/Utilities/NotifyUtilities.cs
+++ b/src/BotCatMaxy/Utilities/NotifyUtilities.cs
@@ -19,14 +19,13 @@ namespace BotCatMaxy
 
             if (color == default) color = Color.LightGrey;
             var embed = new EmbedBuilder()
+                .AddField($"You have been {action}", reason)
                 .WithCurrentTimestamp()
                 .WithGuildAsAuthor(guild)
                 .WithColor(color);
 
             if (!appealLink.IsNullOrEmpty())
-                newReason += $"\n\n[Click here to appeal.]({appealLink})";
-
-            embed.AddField($"You have been {action}", newReason);
+                embed.AddField("Appeal", $"Click **[here]({appealLink})** if you'd like to appeal.");
 
             if (author != null) embed.WithFooter($"Done by {author.Username}#{author.Discriminator}", author.GetAvatarUrl());
             await user.TryNotify(embed.Build());


### PR DESCRIPTION
Users will commonly rejoin servers to ask for ban links, which could be seen as ban bypassing and ruin their chance to appeal.

This PR's goal is to allow server admins to set an appeal link, which would be sent along with the reason in every ban message, This would remove the need to bypass a ban.
![image](https://user-images.githubusercontent.com/41650610/197423115-d6b3f5fa-3444-42f8-8203-adf9671d4f03.png)
![image](https://user-images.githubusercontent.com/41650610/197423118-ab2a3b7f-a8c0-4193-85be-b2aeaefc8a68.png)
![image](https://user-images.githubusercontent.com/41650610/197423121-2b6dd3ed-1b42-4426-a838-82c7d6dde992.png)
